### PR TITLE
Feature/creator facet

### DIFF
--- a/app/assets/stylesheets/findingaids.css.scss
+++ b/app/assets/stylesheets/findingaids.css.scss
@@ -105,6 +105,10 @@ input[type='file'] {
   }
 }
 
+h5.index_title > i {
+  margin-right: .5em;
+}
+
 @media (max-width: 480px) {
   select#search_field {
     width: 100%;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -49,7 +49,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("repository", :stored_sortable), label: "Library", helper_method: :render_repository_facet_link
     config.add_facet_field solr_name("format",     :facetable), :label => "Format",             :limit => 20
     config.add_facet_field solr_name("collection", :facetable), :label => "Collection Name",    :limit => 20
-    config.add_facet_field solr_name("name",       :facetable), :label => "Name",               :limit => 20
+    config.add_facet_field solr_name("creator",    :facetable), :label => "Creator",            :limit => 20
     config.add_facet_field solr_name("subject",    :facetable), :label => "Subject",            :limit => 20
     config.add_facet_field solr_name("genre",      :facetable), :label => "Genre",              :limit => 20
     config.add_facet_field solr_name("series",     :facetable), :label => "Series",             :limit => 20

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -2,12 +2,10 @@ module BlacklightHelper
   include Blacklight::BlacklightHelperBehavior
 
   # Change link to document to link out to external guide
-  def link_to_document(doc, opts={:label=>nil, :counter => nil, :results_view => true})
-    opts[:label] ||= blacklight_config.index.show_link.to_sym
-    # Get label
-    label = render_document_index_label(doc, opts).html_safe
-    # Unescape double escaped entities
-    label = CGI.unescapeHTML(String.new(label.to_s)).html_safe
+  def link_to_document(doc, field, opts={:counter => nil})
+    field ||= document_show_link_field(doc)
+    label = presenter(doc).render_document_index_label field, opts
+
     # Get pathname if series or component, leave nil if is top level collection
     path = (doc[:parent_ssm].blank?) ? (doc[:format_ssm].first == "Archival Collection") ? nil : "dsc#{doc[:ref_ssi]}" : "dsc#{doc[:parent_ssm].first}"
     anchor = (doc[:parent_ssm].blank?) ? nil : doc[:ref_ssi]

--- a/app/views/catalog/_document_header.html.erb
+++ b/app/views/catalog/_document_header.html.erb
@@ -1,11 +1,10 @@
 <% # header bar for doc items in index view -%>
 <div class="documentHeader clearfix">
-  
-  <% # main title container for doc partial view -%>
-    <h5 class="index_title"><%= t('blacklight.search.documents.counter', :counter => (document_counter + 1 + @response.params[:start].to_i)) %><i class="contenttypes-<%= document_icon document %>"></i><%= link_to_document document, :label=>document_show_link_field(document), :counter => (document_counter + 1 + @response.params[:start].to_i) %></h5>
 
-  
+  <% # main title container for doc partial view -%>
+    <h5 class="index_title"><%= t('blacklight.search.documents.counter', :counter => (document_counter + 1 + @response.params[:start].to_i)) %><i class="contenttypes-<%= document_icon document %>"></i><%= link_to_document document, document_show_link_field(document), :counter => (document_counter + 1 + @response.params[:start].to_i) %></h5>
+
+
   <% # bookmark functions for items/docs -%>
   <%= render_index_doc_actions document, :wrapping_class => "documentFunctions col-md-2" %>
 </div>
-

--- a/features/creator_facet.feature
+++ b/features/creator_facet.feature
@@ -1,0 +1,15 @@
+Feature: Creator facet
+  In order to identify which materials are most relevant
+  As a researcher
+  I want to filter my search results by a "Creator" facet.
+
+  Scenario: Pre limit search by a creator facet
+    Given I am on the default search page
+    When I limit my search to "Bytsura, Bill" under the "Creator" category
+    Then I should see search results
+
+  Scenario: Filter search results by a creator facet
+    Given I am on the default search page
+    When I search on the phrase "bill"
+    And I limit my search to "Lefferts family" under the "Creator" category
+    Then I should see search results

--- a/lib/findingaids/ead/component.rb
+++ b/lib/findingaids/ead/component.rb
@@ -28,6 +28,8 @@ class Findingaids::Ead::Component < SolrEad::Component
     Solrizer.insert_field(solr_doc, "location",   location_display,                             :displayable)
     Solrizer.insert_field(solr_doc, "location",   location_display,                             :sortable)
     Solrizer.insert_field(solr_doc, "title",      self.title,                                   :searchable)
+    Solrizer.insert_field(solr_doc, "creator",    get_ead_names,                                :displayable)
+    Solrizer.insert_field(solr_doc, "creator",    get_ead_names,                                :facetable)
 
     # Collection field
     Solrizer.set_field(solr_doc, "collection",        collection_name(solr_doc),          :searchable)
@@ -41,7 +43,7 @@ class Findingaids::Ead::Component < SolrEad::Component
 
     # Set lanuage codes
     solr_doc.merge!(ead_language_fields)
-    
+
     return solr_doc
   end
 

--- a/lib/findingaids/ead/component.rb
+++ b/lib/findingaids/ead/component.rb
@@ -41,7 +41,8 @@ class Findingaids::Ead::Component < SolrEad::Component
 
     # Set lanuage codes
     solr_doc.merge!(ead_language_fields)
-    solr_doc
+    
+    return solr_doc
   end
 
 protected
@@ -95,15 +96,4 @@ protected
   def series_sortable solr_doc
     title_for_heading(solr_doc[Solrizer.solr_name("parent_unittitles", :displayable)]) unless solr_doc[Solrizer.solr_name("parent_unittitles", :displayable)].nil?
   end
-
-private
-
-  def search(path)
-    self.find_by_xpath(path)
-  end
-
-  def value(path)
-    search(path).text
-  end
-
 end

--- a/lib/findingaids/ead/document.rb
+++ b/lib/findingaids/ead/document.rb
@@ -44,7 +44,7 @@ class Findingaids::Ead::Document < SolrEad::Document
     Solrizer.insert_field(solr_doc, "format",       "Archival Collection",  :displayable)
     Solrizer.insert_field(solr_doc, "format",       0,                      :sortable)
     Solrizer.insert_field(solr_doc, "unitdate",     ead_date_display,       :displayable)
-    Solrizer.insert_field(solr_doc, "contributors", get_ead_names,          :displayable)
+    Solrizer.insert_field(solr_doc, "creator",      get_ead_names,          :displayable)
     Solrizer.insert_field(solr_doc, "creator",      get_ead_names,          :facetable)
 
     Solrizer.set_field(solr_doc, "genre",           self.genreform,              :facetable)

--- a/lib/findingaids/ead/document.rb
+++ b/lib/findingaids/ead/document.rb
@@ -45,7 +45,7 @@ class Findingaids::Ead::Document < SolrEad::Document
     Solrizer.insert_field(solr_doc, "format",       0,                      :sortable)
     Solrizer.insert_field(solr_doc, "unitdate",     ead_date_display,       :displayable)
     Solrizer.insert_field(solr_doc, "contributors", get_ead_names,          :displayable)
-    Solrizer.insert_field(solr_doc, "name",         get_ead_names,          :facetable)
+    Solrizer.insert_field(solr_doc, "creator",      get_ead_names,          :facetable)
 
     Solrizer.set_field(solr_doc, "genre",           self.genreform,              :facetable)
     Solrizer.set_field(solr_doc, "genre",           self.genreform,              :displayable)

--- a/lib/tasks/findingaids.rake
+++ b/lib/tasks/findingaids.rake
@@ -24,7 +24,7 @@ namespace :findingaids do
 
   namespace :ead do
 
-    desc "Index ead into solr and create both html and json"
+    desc "Index ead into solr using EAD=<FILE|DIR>"
     task :index => :environment do
       ENV['EAD'] = "spec/fixtures/ead" unless ENV['EAD']
       indexer = Findingaids::Ead::Indexer.new

--- a/spec/fixtures/examples/ead_component.xml
+++ b/spec/fixtures/examples/ead_component.xml
@@ -4,5 +4,11 @@
         <container id="cid17653001" type="Box" label="Mixed materials">1</container>
         <container parent="cid17653001" type="Folder">1</container>
         <unitdate normal="1992/1992">August 19, 1992</unitdate>
+        <origination label="creator">
+          <persname source="local">Bytsura, Bill</persname>
+          <persname source="naf">Belfrage, Sally, 1936-</persname>
+          <corpname rules="Anglo-American_Cataloguing_Rules__2nd_ed." source="naf">Kings County (N.Y.). Board of Supervisors.</corpname>
+          <famname source="naf">Lefferts family</famname>
+        </origination>
     </did>
 </c>

--- a/spec/fixtures/examples/ead_sample.xml
+++ b/spec/fixtures/examples/ead_sample.xml
@@ -47,6 +47,9 @@
             <abstract id="ref6" label="Abstract">Bill Bytsura is a photographer who extensively documented ACT UP and other unaffiliated AIDS awareness movements across the United States and in Europe throughout the late 1980s and 1990s. The collection includes studio-style portraits of each activist, along with their personal statements. Portraits include prominent activists such as Larry Kramer, Ann Northrop, Tim Bailey, Luke Sissyfag Montgomery, Didier Lestrade, Peter Staley, and Terry Stogdell. The collection also documents AIDS demonstrations, political funerals, and related publications.</abstract>
             <origination label="creator">
                 <persname source="local">Bytsura, Bill</persname>
+                <persname source="naf">Belfrage, Sally, 1936-</persname>
+                <corpname rules="Anglo-American_Cataloguing_Rules__2nd_ed." source="naf">Kings County (N.Y.). Board of Supervisors.</corpname>
+                <famname source="naf">Lefferts family</famname>
             </origination>
         </did>
         <relatedmaterial id="ref475">
@@ -89,7 +92,7 @@
             <p>
                 <emph render="bold">Series IV: Ephemera</emph> includes a hat, t-shirts, stickers, pins and postcards.</p>
             <p>Oversize materials are listed at the end of the finding aid:</p>
-            <p>Series I Oversize: Portraits 
+            <p>Series I Oversize: Portraits
                 <lb/> Series II Oversize: Demonstrations
                 <lb/> Series III Oversize: Press, Promotion, and Adminstrative Files
                 <lb/> Series IV Oversize: Posters</p>

--- a/spec/fixtures/examples/ead_sample.xml
+++ b/spec/fixtures/examples/ead_sample.xml
@@ -146,6 +146,10 @@
                         <container id="cid17653001" type="Box" label="Mixed materials">1</container>
                         <container parent="cid17653001" type="Folder">1</container>
                         <unitdate normal="1992/1992">August 19, 1992</unitdate>
+                        <origination label="creator">
+                          <persname source="local">Component Level Name</persname>
+                          <famname source="naf">Lefferts family</famname>
+                        </origination>
                     </did>
                 </c>
                 <c id="ref15" level="file">

--- a/spec/fixtures/fales/bloch.xml
+++ b/spec/fixtures/fales/bloch.xml
@@ -3,7 +3,7 @@
         <eadid>bloch</eadid>
         <filedesc>
             <titlestmt>
-                <titleproper>Mark Bloch Postal Art Network (PAN) Archive, 
+                <titleproper>Mark Bloch Postal Art Network (PAN) Archive,
                     <lb/>1978-2012
                     <lb/>
                     <num>MSS 170</num>
@@ -47,6 +47,12 @@
             </physdesc>
             <unitdate normal="1978/2012" type="inclusive">1978-2012</unitdate>
             <abstract id="ref11" label="Abstract">Mark Bloch is an American fine artist and writer whose work utilizes both visuals and text to explore ideas of long distance communication. This collection contains thousands of examples of original “mail art” sent to and collected by Mark Bloch in New York City from all fifty states and dozens of countries in the form of objects, envelopes, artwork, and enclosures as well as publications, postcards and announcements documenting avant garde cultural activities in various media during the years 1978 to 2013.</abstract>
+            <origination label="creator">
+              <persname source="local">Bytsura, Bill</persname>
+              <persname source="naf">Belfrage, Sally, 1936-</persname>
+              <corpname rules="Anglo-American_Cataloguing_Rules__2nd_ed." source="naf">Kings County (N.Y.). Board of Supervisors.</corpname>
+              <famname source="naf">Lefferts family</famname>
+            </origination>
         </did>
         <bioghist id="ref12">
             <head>Biographical/Historical note</head>

--- a/spec/fixtures/fales/bytsura.xml
+++ b/spec/fixtures/fales/bytsura.xml
@@ -47,6 +47,9 @@
     <abstract id="ref6" label="Abstract">Bill Bytsura is a photographer who extensively documented ACT UP and other unaffiliated AIDS awareness movements across the United States and in Europe throughout the late 1980s and 1990s. The collection includes studio-style portraits of each activist, along with their personal statements. Portraits include prominent activists such as Larry Kramer, Ann Northrop, Tim Bailey, Luke Sissyfag Montgomery, Didier Lestrade, Peter Staley, and Terry Stogdell. The collection also documents AIDS demonstrations, political funerals, and related publications.</abstract>
     <origination label="creator">
       <persname source="local">Bytsura, Bill</persname>
+      <persname source="naf">Belfrage, Sally, 1936-</persname>
+      <corpname rules="Anglo-American_Cataloguing_Rules__2nd_ed." source="naf">Kings County (N.Y.). Board of Supervisors.</corpname>
+      <famname source="naf">Lefferts family</famname>
     </origination>
   </did>
   <relatedmaterial id="ref475">

--- a/spec/helpers/results_helper_spec.rb
+++ b/spec/helpers/results_helper_spec.rb
@@ -170,7 +170,7 @@ describe ResultsHelper do
   end
 
   describe "#link_to_document" do
-    subject { link_to_document(collection, { label: heading }) }
+    subject { link_to_document(collection, heading) }
     let(:collection) { document[:document] }
     context "when document is a collection level item" do
       it { should eql("<a href=\"http://dlib.nyu.edu/findingaids/html/fales/testead/\" target=\"_blank\">Guide to titling finding aids</a>") }

--- a/spec/lib/findingaids/ead/behaviors_spec.rb
+++ b/spec/lib/findingaids/ead/behaviors_spec.rb
@@ -4,7 +4,7 @@ describe Findingaids::Ead::Behaviors do
 
   include Findingaids::Ead::Behaviors
 
-  describe ".format_publisher" do
+  describe "#format_publisher" do
 
     it "should strip ugly characters from publisher" do
       expect(format_publisher(["@ 2012 Fales Library and Special Collections     "])).to eql("Fales Library and Special Collections")
@@ -12,7 +12,7 @@ describe Findingaids::Ead::Behaviors do
 
   end
 
-  describe ".format_repository" do
+  describe "#format_repository" do
 
     subject { format_repository }
 
@@ -35,7 +35,7 @@ describe Findingaids::Ead::Behaviors do
 
   end
 
-  describe ".get_language_from_code" do
+  describe "#get_language_from_code" do
 
     let(:language_code) { "eng" }
 
@@ -52,8 +52,5 @@ describe Findingaids::Ead::Behaviors do
 
   end
 
-  describe ".ead_date_display" do
-
-  end
 
 end

--- a/spec/lib/findingaids/ead/component_spec.rb
+++ b/spec/lib/findingaids/ead/component_spec.rb
@@ -18,7 +18,7 @@ describe Findingaids::Ead::Component do
       Solrizer.solr_name("component_children", :type => :boolean) => FALSE
     }
   end
-  
+
   describe "#to_solr" do
 
     subject(:solr_doc) { document.to_solr(additional_fields) }
@@ -28,19 +28,19 @@ describe Findingaids::Ead::Component do
       it { expect(solr_doc[Solrizer.solr_name("level", :facetable)]).to include "item" }
       it { expect(solr_doc[Solrizer.solr_name("location", :displayable)]).to include "Box: 1, Folder: 1" }
     end
-        
+
     context "when component doesn't have a title" do
       let(:document) { Findingaids::Ead::Component.from_xml(ead_fixture("ead_component2.xml")) }
       it { expect(solr_doc[Solrizer.solr_name("heading", :displayable)]).to include "August 19, 1992" }
     end
-    
+
   end
-  
-  describe ".title_for_heading" do  
+
+  describe ".title_for_heading" do
     let(:parent_unittitles) { nil }
     let(:solr_doc) { document.to_solr(additional_fields) }
-    
+
     it { expect(document.send(:title_for_heading)).to eql("[ACT UP Paris]") }
   end
-  
+
 end

--- a/spec/lib/findingaids/ead/component_spec.rb
+++ b/spec/lib/findingaids/ead/component_spec.rb
@@ -23,6 +23,10 @@ describe Findingaids::Ead::Component do
 
     subject(:solr_doc) { document.to_solr(additional_fields) }
 
+    describe "creator facet" do
+      it { expect(solr_doc[Solrizer.solr_name("creator", :facetable)]).to eql ["Belfrage, Sally, 1936-", "Bytsura, Bill", "Kings County (N.Y.). Board of Supervisors.", "Lefferts family"] }
+    end
+
     context "when component has parent titles" do
       it { expect(solr_doc["id"]).to eql("TEST-0001ref010") }
       it { expect(solr_doc[Solrizer.solr_name("level", :facetable)]).to include "item" }

--- a/spec/lib/findingaids/ead/document_spec.rb
+++ b/spec/lib/findingaids/ead/document_spec.rb
@@ -2,30 +2,34 @@ require 'spec_helper'
 
 describe Findingaids::Ead::Document do
 
-  let(:document) do
-    Findingaids::Ead::Document.from_xml(ead_fixture("ead_sample.xml"))
-  end
-  
+  let(:document) { Findingaids::Ead::Document.from_xml(ead_fixture("ead_sample.xml")) }
+
   describe "#to_solr" do
 
     let(:solr_doc) { document.to_solr }
 
-    context "when there is a valid date" do
-      it { expect(solr_doc["id"]).to eql("bytsura") }
-      it { expect(solr_doc[Solrizer.solr_name("unitdate", :displayable)]).to include "Inclusive, 1981-2012 ; Bulk, 1989-1997" }
-      it { expect(solr_doc[Solrizer.solr_name("contributors", :displayable)]).to include "Bytsura, Bill" }
-      it { expect(solr_doc[Solrizer.solr_name("name", :facetable)]).to include "Bytsura, Bill" }
-      it { expect(solr_doc[Solrizer.solr_name("heading", :displayable)]).to include "Guide to the Bill Bytsura ACT UP Photography Collection (MSS 313)" }
-      it { expect(solr_doc[Solrizer.solr_name("subject", :facetable)]).to include "ACT UP (Organization)" }
-      it { expect(solr_doc[Solrizer.solr_name("title", :displayable)]).to include "Bill Bytsura ACT UP Photography Collection" }
-      it { expect(solr_doc[Solrizer.solr_name("title_filing", :sortable)]).to include "Bill Bytsura ACT UP Photography Collection" }
+    it { expect(solr_doc["id"]).to eql("bytsura") }
+    it { expect(solr_doc[Solrizer.solr_name("contributors", :displayable)]).to include "Bytsura, Bill" }
+    it { expect(solr_doc[Solrizer.solr_name("heading", :displayable)]).to include "Guide to the Bill Bytsura ACT UP Photography Collection (MSS 313)" }
+    it { expect(solr_doc[Solrizer.solr_name("subject", :facetable)]).to include "ACT UP (Organization)" }
+    it { expect(solr_doc[Solrizer.solr_name("title", :displayable)]).to include "Bill Bytsura ACT UP Photography Collection" }
+    it { expect(solr_doc[Solrizer.solr_name("title_filing", :sortable)]).to include "Bill Bytsura ACT UP Photography Collection" }
+
+    describe "creator facet" do
+      it { expect(solr_doc[Solrizer.solr_name("creator", :facetable)]).to eql ["Belfrage, Sally, 1936-", "Bytsura, Bill", "Kings County (N.Y.). Board of Supervisors.", "Lefferts family"] }
     end
-    
-    context "when there is no valid date" do
-      let(:document) { Findingaids::Ead::Document.from_xml(ead_fixture("ead_template.xml")) }
-      it { expect(solr_doc[Solrizer.solr_name("unitdate", :displayable)]).to include "sample date" }
+
+    describe "date display" do
+      context "when there is a valid date" do
+        it { expect(solr_doc[Solrizer.solr_name("unitdate", :displayable)]).to include "Inclusive, 1981-2012 ; Bulk, 1989-1997" }
+      end
+
+      context "when there is no valid date" do
+        let(:document) { Findingaids::Ead::Document.from_xml(ead_fixture("ead_template.xml")) }
+        it { expect(solr_doc[Solrizer.solr_name("unitdate", :displayable)]).to include "sample date" }
+      end
     end
-    
+
   end
-  
+
 end

--- a/spec/lib/findingaids/ead/document_spec.rb
+++ b/spec/lib/findingaids/ead/document_spec.rb
@@ -9,14 +9,13 @@ describe Findingaids::Ead::Document do
     let(:solr_doc) { document.to_solr }
 
     it { expect(solr_doc["id"]).to eql("bytsura") }
-    it { expect(solr_doc[Solrizer.solr_name("contributors", :displayable)]).to include "Bytsura, Bill" }
     it { expect(solr_doc[Solrizer.solr_name("heading", :displayable)]).to include "Guide to the Bill Bytsura ACT UP Photography Collection (MSS 313)" }
     it { expect(solr_doc[Solrizer.solr_name("subject", :facetable)]).to include "ACT UP (Organization)" }
     it { expect(solr_doc[Solrizer.solr_name("title", :displayable)]).to include "Bill Bytsura ACT UP Photography Collection" }
     it { expect(solr_doc[Solrizer.solr_name("title_filing", :sortable)]).to include "Bill Bytsura ACT UP Photography Collection" }
 
     describe "creator facet" do
-      it { expect(solr_doc[Solrizer.solr_name("creator", :facetable)]).to eql ["Belfrage, Sally, 1936-", "Bytsura, Bill", "Kings County (N.Y.). Board of Supervisors.", "Lefferts family"] }
+      it { expect(solr_doc[Solrizer.solr_name("creator", :facetable)]).to eql ["Belfrage, Sally, 1936-", "Bytsura, Bill", "Component Level Name", "Kings County (N.Y.). Board of Supervisors.", "Lefferts family"] }
     end
 
     describe "date display" do


### PR DESCRIPTION
@NYULibraries/finding-aids I'm waiting for travis to pass here but I think it's good to go. Please let me know any questions or comments before the end of the week so I can merge back before the weekly reindex.

- Changed "Name" facet to "Creator" and changed where we're pulling the information from;
- Populate creators at the component level as well;
- Updated `link_to_document` to match new BL8 format and stop annoying deprecation warning;
- Additional style tweaks and general code cleanup