### PR TITLE
Feature/change display order

### DIFF
--- a/app/assets/stylesheets/findingaids.css.scss
+++ b/app/assets/stylesheets/findingaids.css.scss
@@ -112,6 +112,15 @@ h5.index_title > i {
 .result_ut{
   font-weight: bold;
 }
+
+.search_within{
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.request_item_note{
+  padding-top:10px;
+}
 @media (max-width: 480px) {
   select#search_field {
     width: 100%;

--- a/app/assets/stylesheets/findingaids.css.scss
+++ b/app/assets/stylesheets/findingaids.css.scss
@@ -109,6 +109,9 @@ h5.index_title > i {
   margin-right: .5em;
 }
 
+.result_ut{
+  font-weight: bold;
+}
 @media (max-width: 480px) {
   select#search_field {
     width: 100%;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -73,7 +73,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name("unittitle",         :displayable),  :label => "Title", :highlight => true, :helper_method => :render_field_item
     config.add_index_field solr_name("format",            :displayable),  :label => "Format", :helper_method => :render_field_item
-    config.add_index_field solr_name("unitdate",          :displayable),  :label => "Dates", :helper_method => :render_field_item
+    config.add_index_field solr_name("unitdate",          :displayable),  :label => "Date range", :helper_method => :render_field_item
     config.add_index_field solr_name("abstract",          :displayable),  :label => "Abstract", :highlight => true, :helper_method => :render_field_item
     config.add_index_field solr_name("language",          :displayable),  :label => "Language", :helper_method => :render_field_item
     config.add_index_field solr_name("collection",        :displayable),  :label => "Archival Collection", :helper_method => :render_collection_facet_link, :highlight => true

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -73,7 +73,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name("unittitle",         :displayable),  :label => "Title", :highlight => true, :helper_method => :render_field_item
     config.add_index_field solr_name("format",            :displayable),  :label => "Format", :helper_method => :render_field_item
-    config.add_index_field solr_name("breadcrumb",        :displayable),  :label => "Contained in", :helper_method => :render_field_item
+    config.add_index_field solr_name("breadcrumb",        :displayable),  :label => "Contained in", :helper_method => :render_breadcrumb
     config.add_index_field solr_name("unitdate",          :displayable),  :label => "Date range", :helper_method => :render_field_item
     config.add_index_field solr_name("abstract",          :displayable),  :label => "Abstract", :highlight => true, :helper_method => :render_field_item
     config.add_index_field solr_name("language",          :displayable),  :label => "Language", :helper_method => :render_field_item

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,14 +71,14 @@ class CatalogController < ApplicationController
     # ------------------------------------------------------------------------------------------
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field solr_name("unittitle",         :displayable),  :label => "Title", :highlight => true, :helper_method => :render_field_item
+    #config.add_index_field solr_name("unittitle",         :displayable),  :label => "Title", :highlight => true, :helper_method => :render_field_item
     config.add_index_field solr_name("format",            :displayable),  :label => "Format", :helper_method => :render_field_item
     config.add_index_field solr_name("breadcrumb",        :displayable),  :label => "Contained in", :helper_method => :render_breadcrumb
     config.add_index_field solr_name("unitdate",          :displayable),  :label => "Date range", :helper_method => :render_field_item
     config.add_index_field solr_name("abstract",          :displayable),  :label => "Abstract", :highlight => true, :helper_method => :render_field_item
-    config.add_index_field solr_name("language",          :displayable),  :label => "Language", :helper_method => :render_field_item
-    config.add_index_field solr_name("collection",        :displayable),  :label => "Archival Collection", :helper_method => :render_collection_facet_link, :highlight => true
-    config.add_index_field solr_name("parent_unittitles", :displayable),  :label => "Series", :highlight => true, :helper_method => :render_series_facet_link
+    #config.add_index_field solr_name("language",          :displayable),  :label => "Language", :helper_method => :render_field_item
+    #config.add_index_field solr_name("collection",        :displayable),  :label => "Archival Collection", :helper_method => :render_collection_facet_link, :highlight => true
+    #config.add_index_field solr_name("parent_unittitles", :displayable),  :label => "Series", :highlight => true, :helper_method => :render_series_facet_link
     config.add_index_field solr_name("repository",        :stored_sortable), label: "Library", helper_method: :render_repository_facet_link
     config.add_index_field solr_name("unitid",            :displayable),  :label => "Call no", :highlight => true, :helper_method => :render_field_item
     config.add_index_field solr_name("location",          :displayable),  :label => "Location", :highlight => true, :helper_method => :render_field_item

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,14 +71,15 @@ class CatalogController < ApplicationController
     # ------------------------------------------------------------------------------------------
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field solr_name("repository",        :stored_sortable), label: "Library", helper_method: :render_repository_facet_link
     config.add_index_field solr_name("unittitle",         :displayable),  :label => "Title", :highlight => true, :helper_method => :render_field_item
-    config.add_index_field solr_name("abstract",          :displayable),  :label => "Abstract", :highlight => true, :helper_method => :render_field_item
     config.add_index_field solr_name("format",            :displayable),  :label => "Format", :helper_method => :render_field_item
-    config.add_index_field solr_name("language",          :displayable),  :label => "Language", :helper_method => :render_field_item
     config.add_index_field solr_name("unitdate",          :displayable),  :label => "Dates", :helper_method => :render_field_item
+    config.add_index_field solr_name("abstract",          :displayable),  :label => "Abstract", :highlight => true, :helper_method => :render_field_item
+    config.add_index_field solr_name("language",          :displayable),  :label => "Language", :helper_method => :render_field_item
     config.add_index_field solr_name("collection",        :displayable),  :label => "Archival Collection", :helper_method => :render_collection_facet_link, :highlight => true
     config.add_index_field solr_name("parent_unittitles", :displayable),  :label => "Series", :highlight => true, :helper_method => :render_series_facet_link
+    config.add_index_field solr_name("repository",        :stored_sortable), label: "Library", helper_method: :render_repository_facet_link
+    config.add_index_field solr_name("unitid",            :displayable),  :label => "Call no", :highlight => true, :helper_method => :render_field_item
     config.add_index_field solr_name("location",          :displayable),  :label => "Location", :highlight => true, :helper_method => :render_field_item
 
     # ------------------------------------------------------------------------------------------

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -73,6 +73,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name("unittitle",         :displayable),  :label => "Title", :highlight => true, :helper_method => :render_field_item
     config.add_index_field solr_name("format",            :displayable),  :label => "Format", :helper_method => :render_field_item
+    config.add_index_field solr_name("breadcrumb",        :displayable),  :label => "Contained in", :helper_method => :render_field_item
     config.add_index_field solr_name("unitdate",          :displayable),  :label => "Date range", :helper_method => :render_field_item
     config.add_index_field solr_name("abstract",          :displayable),  :label => "Abstract", :highlight => true, :helper_method => :render_field_item
     config.add_index_field solr_name("language",          :displayable),  :label => "Language", :helper_method => :render_field_item

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -24,10 +24,16 @@ module ResultsHelper
 
   def render_breadcrumb(doc)
     bcrumbs = doc[:document][doc[:field]].join(" >> ").split(" >> ")
-    bc = content_tag(:span,bcrumbs.last, class: "result_ut")
+     collection = doc[:document][Solrizer.solr_name("collection", :displayable)].first
+     bc = content_tag(:span,bcrumbs.last, class: "result_ut")
     bcrumbs.pop
+     links_to_series = []
+    bcrumbs.each do |ser|
+      links_to_series << link_to(ser, add_clean_facet_params_and_redirect([series_facet, ser],[collection_facet, collection]))
+    end
+    
     #bcrumbs.map{ |b| b.eql? bcrumbs.last ? bc : b }
-    [bcrumbs,bc].join(" >> ").html_safe 
+    [links_to_series,bc].join(" >> ").html_safe 
   end
   def render_repository_facet_link(doc)
     repos_id = Solrizer.solr_name("repository", :stored_sortable)

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -22,17 +22,19 @@ module ResultsHelper
     [links_to_series].join(" >> ").html_safe
   end
 
+  # Getting list of collection and parent titles
+  # Getting the list in the form of an array
+  # Converting that into a string and then an easier to navigate array
   def render_breadcrumb(doc)
     bcrumbs = doc[:document][doc[:field]].join(" >> ").split(" >> ")
-     collection = doc[:document][Solrizer.solr_name("collection", :displayable)].first
-     bc = content_tag(:span,bcrumbs.last, class: "result_ut")
+    collection = doc[:document][Solrizer.solr_name("collection", :displayable)].first
+    bc = content_tag(:span,bcrumbs.last, class: "result_ut")
     bcrumbs.pop
-     links_to_series = []
+    links_to_series = []
     bcrumbs.each do |ser|
-      links_to_series << link_to(ser, add_clean_facet_params_and_redirect([series_facet, ser],[collection_facet, collection]))
+        links_to_series << link_to(ser, add_clean_facet_params_and_redirect([series_facet, ser],[collection_facet, collection]))
     end
     
-    #bcrumbs.map{ |b| b.eql? bcrumbs.last ? bc : b }
     [links_to_series,bc].join(" >> ").html_safe 
   end
   def render_repository_facet_link(doc)

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -22,6 +22,13 @@ module ResultsHelper
     [links_to_series].join(" >> ").html_safe
   end
 
+  def render_breadcrumb(doc)
+    bcrumbs = doc[:document][doc[:field]].join(" >> ").split(" >> ")
+    bc = content_tag(:span,bcrumbs.last, class: "result_ut")
+    bcrumbs.pop
+    #bcrumbs.map{ |b| b.eql? bcrumbs.last ? bc : b }
+    [bcrumbs,bc].join(" >> ").html_safe 
+  end
   def render_repository_facet_link(doc)
     repos_id = Solrizer.solr_name("repository", :stored_sortable)
     if doc.is_a?(Hash) && doc[:document].present? && doc[:document][repos_id].present?

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -93,7 +93,8 @@ module ResultsHelper
     end
   end
 
-  def pick_order_fields(doc, fields, *list_fields)
+  # renders fields; has an option to submit a list of fields
+  def pick_fields(doc, fields, *list_fields)
     items = []
     values = []
     fields.each{ |solr_fname, field|

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -34,8 +34,9 @@ module ResultsHelper
     bcrumbs.each do |ser|
         links_to_series << link_to(ser, add_clean_facet_params_and_redirect([series_facet, ser],[collection_facet, collection]))
     end
-    
+   
     [links_to_series,bc].join(" >> ").html_safe 
+    
   end
   def render_repository_facet_link(doc)
     repos_id = Solrizer.solr_name("repository", :stored_sortable)
@@ -92,6 +93,29 @@ module ResultsHelper
     end
   end
 
+  def pick_order_fields(doc, fields, publish, *list_fields)
+    hsh = {}
+    items = []
+    values = []
+    fields.each{ |solr_fname, field|
+      unless publish == "yes" and list_fields.include? field.label
+        if should_render_index_field?(doc, field)
+          label = content_tag(:dt, render_index_field_label(:field => solr_fname),class:"blacklight-#{solr_fname.parameterize}")
+          value = content_tag(:dd, render_index_field_value(:document => doc, :field => solr_fname),class:"blacklight-#{solr_fname.parameterize}")
+          items << [label,value]
+          
+          #hsh[k] = v
+          #content_tag(:dt, render_index_field_label(:field => solr_fname),class:"blacklight-#{solr_fname.parameterize}").html_safe
+          #content_tag(:dd, render_index_field_value(:document => doc, :field => solr_fname),class:"blacklight-#{solr_fname.parameterize}").html_safe 
+        end
+      end
+      
+    }
+    items.join("").html_safe
+    #[labels,values].join("").html_safe
+
+    
+  end
   # Get icon from format type
   def document_icon(doc)
     doc.normalized_format

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -94,25 +94,30 @@ module ResultsHelper
   end
 
   def pick_order_fields(doc, fields, publish, *list_fields)
-    hsh = {}
     items = []
     values = []
     fields.each{ |solr_fname, field|
-      unless publish == "yes" and list_fields.include? field.label
+      if publish == "yes" and list_fields[0].split(",").include? field.label
+        #binding.pry
         if should_render_index_field?(doc, field)
-          label = content_tag(:dt, render_index_field_label(:field => solr_fname),class:"blacklight-#{solr_fname.parameterize}")
-          value = content_tag(:dd, render_index_field_value(:document => doc, :field => solr_fname),class:"blacklight-#{solr_fname.parameterize}")
+          # have to do the following because it wasn't rendering the html correctly otherwise
+          item_label = render_index_field_label(:field => solr_fname)
+          label = content_tag(:dt, item_label,class:"blacklight-#{solr_fname.parameterize}")
+          item_value = render_index_field_value(:document => doc, :field => solr_fname)
+          item_value = item_value.truncate(450) if field.label == "Abstract"
+          #binding.pry if field.label == "Abstract"
+          value = content_tag(:dd, item_value,class:"blacklight-#{solr_fname.parameterize}")
+
           items << [label,value]
           
-          #hsh[k] = v
-          #content_tag(:dt, render_index_field_label(:field => solr_fname),class:"blacklight-#{solr_fname.parameterize}").html_safe
-          #content_tag(:dd, render_index_field_value(:document => doc, :field => solr_fname),class:"blacklight-#{solr_fname.parameterize}").html_safe 
+          #content_tag(:dt, render_index_field_label(:field => solr_fname),class:"blacklight-#{solr_fname.parameterize}")
+          #content_tag(:dd, render_index_field_value(:document => doc, :field => solr_fname),class:"blacklight-#{solr_fname.parameterize}")
         end
       end
       
     }
     items.join("").html_safe
-    #[labels,values].join("").html_safe
+   
 
     
   end

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -97,7 +97,9 @@ module ResultsHelper
     items = []
     values = []
     fields.each{ |solr_fname, field|
-      if list_fields[0].split(",").include? field.label 
+      # if optional list fields arg list is empty, i.e. print all fields
+      # or print list of fields
+      if list_fields[0].nil? or list_fields[0].split(",").include? field.label 
        
         if should_render_index_field?(doc, field)
           # have to do the following because it wasn't rendering the html correctly otherwise

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -93,19 +93,20 @@ module ResultsHelper
     end
   end
 
-  def pick_order_fields(doc, fields, publish, *list_fields)
+  def pick_order_fields(doc, fields, *list_fields)
     items = []
     values = []
     fields.each{ |solr_fname, field|
-      if publish == "yes" and list_fields[0].split(",").include? field.label
-        #binding.pry
+      if list_fields[0].split(",").include? field.label 
+       
         if should_render_index_field?(doc, field)
           # have to do the following because it wasn't rendering the html correctly otherwise
           item_label = render_index_field_label(:field => solr_fname)
           label = content_tag(:dt, item_label,class:"blacklight-#{solr_fname.parameterize}")
           item_value = render_index_field_value(:document => doc, :field => solr_fname)
+          #truncating abstract to 450 chars
           item_value = item_value.truncate(450) if field.label == "Abstract"
-          #binding.pry if field.label == "Abstract"
+         
           value = content_tag(:dd, item_value,class:"blacklight-#{solr_fname.parameterize}")
 
           items << [label,value]

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,6 +1,6 @@
 <%# default partial to display solr document fields in catalog index view -%>
 <dl class="dl-horizontal dl-invert">
-  <%= pick_order_fields document, index_fields, "yes", "Format,Date range,Abstract,Contained in" %>
+  <%= pick_order_fields document, index_fields, "Format,Date range,Abstract,Contained in" %>
   
   <% if document.is_archival_collection? %>
     <dd class="search_within"><b><%= link_to "Click here to search within collection", render_components_facet_link(document) %></b></dd>
@@ -9,6 +9,6 @@
      <% elsif document.is_archival_object? %>
     <dd class="request_item_note"><b>To request this item, please note the following information</b></dd>
   <% end %>
-  <%= pick_order_fields document, index_fields, "yes", "Library,Call no,Location" %>
+  <%= pick_order_fields document, index_fields,  "Library,Call no,Location" %>
  
 </dl>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,10 +1,12 @@
 <%# default partial to display solr document fields in catalog index view -%>
 <dl class="dl-horizontal dl-invert">
 
-  <% index_fields.each do |solr_fname, field| -%>
+  <% index_fields.each do |solr_fname, field| -%> 
     <% if should_render_index_field? document, field %>
+       <% if not((field.label == "Library") || (field.label == "Call no")) %>
 	      <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
 	      <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value :document => document, :field => solr_fname %></dd>
+        <% end -%>
     <% end -%>
   <% end -%>
   <% if document.is_archival_collection? %>
@@ -20,6 +22,13 @@
   <dt>Archival Items:</dt>
     <dd><b><%= link_to "Click here to search within series", render_components_for_series_facet_link(document) %></b></dd>
   <% end %>
-
-
+  <!-- need to create a function for this -->
+  <% index_fields.each do |solr_fname, field| -%> 
+    <% if should_render_index_field? document, field %>
+    <% if ((field.label == "Library") || (field.label == "Call no")) %>
+        <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
+        <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value :document => document, :field => solr_fname %></dd>
+        <% end -%>
+    <% end -%>
+  <% end -%>
 </dl>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,5 +1,6 @@
 <%# default partial to display solr document fields in catalog index view -%>
 <dl class="dl-horizontal dl-invert">
+  
   <%= pick_order_fields document, index_fields, "Format,Date range,Abstract,Contained in" %>
   
   <% if document.is_archival_collection? %>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -5,7 +5,15 @@
     <% if should_render_index_field? document, field %>
        <% if not((field.label == "Library") || (field.label == "Call no")) %>
 	      <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
-	      <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value :document => document, :field => solr_fname %></dd>
+	      <dd class="blacklight-<%= solr_fname.parameterize %>">
+          <% if field.label == "Abstract" %>
+            <% abstract = render_index_field_value :document => document, :field => solr_fname %>
+            <%= truncate abstract, length:450 %>
+          <% else %>
+             <%= render_index_field_value :document => document, :field => solr_fname %>
+          <% end -%>
+        </dd>
+       
         <% end -%>
     <% end -%>
   <% end -%>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -3,7 +3,8 @@
 
   <% index_fields.each do |solr_fname, field| -%> 
     <% if should_render_index_field? document, field %>
-       <% if not((field.label == "Library") || (field.label == "Call no") || (field.label == "Title") || (field.label == "Location")) %>
+
+       <% if not((field.label == "Library") || (field.label == "Call no") ||  (field.label == "Location")) %>
 	      <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
 	      <dd class="blacklight-<%= solr_fname.parameterize %>">
           <% if field.label == "Abstract" %>
@@ -24,7 +25,8 @@
      <% elsif document.is_archival_object? %>
     <dd class="request_item_note"><b>To request this item, please note the following information</b></dd>
   <% end %>
-  <!-- need to create a function for this -->
+  <%= pick_order_fields document, index_fields, "yes", "['Library', 'Call no']" %>
+  <!-- need to create a function for this 
   <% index_fields.each do |solr_fname, field| -%> 
     <% if should_render_index_field? document, field %>
     <% if ((field.label == "Library") || (field.label == "Call no") || (field.label == "Location")) %>
@@ -32,5 +34,5 @@
         <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value :document => document, :field => solr_fname %></dd>
         <% end -%>
     <% end -%>
-  <% end -%>
+  <% end -%>-->
 </dl>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -18,17 +18,11 @@
     <% end -%>
   <% end -%>
   <% if document.is_archival_collection? %>
-  <dt>Table of Contents:</dt>
-    <%= link_to_toc_page document, "Descriptive Summary", "abstract" %>
-    <%= link_to_toc_page document, "Historical/Biographical Note", "bioghist" %>
-    <%= link_to_toc_page document, "Scope and Content Note and Arrangement", "scopecontent" %>
-    <%= link_to_toc_page document, "Access Points", "controlaccess" %>
-    <%= link_to_toc_page document, "Administrative Information", "admininfo" %>
-  <dt>Archival Items:</dt>
-    <dd><b><%= link_to "Click here to search within collection", render_components_facet_link(document) %></b></dd>
+    <dd class="search_within"><b><%= link_to "Click here to search within collection", render_components_facet_link(document) %></b></dd>
   <% elsif document.is_archival_series? %>
-  <dt>Archival Items:</dt>
-    <dd><b><%= link_to "Click here to search within series", render_components_for_series_facet_link(document) %></b></dd>
+    <dd class="search_within"><b><%= link_to "Click here to search within series", render_components_for_series_facet_link(document) %></b></dd>
+     <% elsif document.is_archival_object? %>
+    <dd class="request_item_note"><b>To request this item, please note the following information</b></dd>
   <% end %>
   <!-- need to create a function for this -->
   <% index_fields.each do |solr_fname, field| -%> 

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,23 +1,7 @@
 <%# default partial to display solr document fields in catalog index view -%>
 <dl class="dl-horizontal dl-invert">
-
-  <% index_fields.each do |solr_fname, field| -%> 
-    <% if should_render_index_field? document, field %>
-
-       <% if not((field.label == "Library") || (field.label == "Call no") ||  (field.label == "Location")) %>
-	      <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
-	      <dd class="blacklight-<%= solr_fname.parameterize %>">
-          <% if field.label == "Abstract" %>
-            <% abstract = render_index_field_value :document => document, :field => solr_fname %>
-            <%= truncate abstract, length:450 %>
-          <% else %>
-             <%= render_index_field_value :document => document, :field => solr_fname %>
-          <% end -%>
-        </dd>
-       
-        <% end -%>
-    <% end -%>
-  <% end -%>
+  <%= pick_order_fields document, index_fields, "yes", "Format,Date range,Abstract,Contained in" %>
+  
   <% if document.is_archival_collection? %>
     <dd class="search_within"><b><%= link_to "Click here to search within collection", render_components_facet_link(document) %></b></dd>
   <% elsif document.is_archival_series? %>
@@ -25,14 +9,6 @@
      <% elsif document.is_archival_object? %>
     <dd class="request_item_note"><b>To request this item, please note the following information</b></dd>
   <% end %>
-  <%= pick_order_fields document, index_fields, "yes", "['Library', 'Call no']" %>
-  <!-- need to create a function for this 
-  <% index_fields.each do |solr_fname, field| -%> 
-    <% if should_render_index_field? document, field %>
-    <% if ((field.label == "Library") || (field.label == "Call no") || (field.label == "Location")) %>
-        <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
-        <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value :document => document, :field => solr_fname %></dd>
-        <% end -%>
-    <% end -%>
-  <% end -%>-->
+  <%= pick_order_fields document, index_fields, "yes", "Library,Call no,Location" %>
+ 
 </dl>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,7 +1,7 @@
 <%# default partial to display solr document fields in catalog index view -%>
 <dl class="dl-horizontal dl-invert">
-  
-  <%= pick_order_fields document, index_fields, "Format,Date range,Abstract,Contained in" %>
+
+  <%= pick_fields document, index_fields, "Format,Date range,Abstract,Contained in" %>
   
   <% if document.is_archival_collection? %>
     <dd class="search_within"><b><%= link_to "Click here to search within collection", render_components_facet_link(document) %></b></dd>
@@ -10,6 +10,6 @@
      <% elsif document.is_archival_object? %>
     <dd class="request_item_note"><b>To request this item, please note the following information</b></dd>
   <% end %>
-  <%= pick_order_fields document, index_fields,  "Library,Call no,Location" %>
+  <%= pick_fields document, index_fields,  "Library,Call no,Location" %>
  
 </dl>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -3,7 +3,7 @@
 
   <% index_fields.each do |solr_fname, field| -%> 
     <% if should_render_index_field? document, field %>
-       <% if not((field.label == "Library") || (field.label == "Call no")) %>
+       <% if not((field.label == "Library") || (field.label == "Call no") || (field.label == "Title") || (field.label == "Location")) %>
 	      <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
 	      <dd class="blacklight-<%= solr_fname.parameterize %>">
           <% if field.label == "Abstract" %>
@@ -33,7 +33,7 @@
   <!-- need to create a function for this -->
   <% index_fields.each do |solr_fname, field| -%> 
     <% if should_render_index_field? document, field %>
-    <% if ((field.label == "Library") || (field.label == "Call no")) %>
+    <% if ((field.label == "Library") || (field.label == "Call no") || (field.label == "Location")) %>
         <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label :field => solr_fname %></dt>
         <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value :document => document, :field => solr_fname %></dd>
         <% end -%>

--- a/lib/findingaids/ead/behaviors/component.rb
+++ b/lib/findingaids/ead/behaviors/component.rb
@@ -30,6 +30,19 @@ module Findingaids::Ead::Behaviors
       end
     end
 
+    # Prints titles for archival object breadcrumb
+    #
+    # Also adds collection name to the top of the breadcrumb 
+    # E.g Collection Name >> Series I >> Sub-series II >> Unit
+    def bread_crumb(solr_doc)
+      #get collection name
+      coll_name = collection_name(solr_doc)
+      #get breadcrumb
+      bc = title_for_heading(solr_doc[Solrizer.solr_name("parent_unittitles", :displayable)])
+      [coll_name,bc].join(" >> ")
+     
+    end
+
     # Extract collection name from solr_doc
     # it was passed in via additional information from the collection level indexer
     def collection_name(solr_doc)

--- a/lib/findingaids/ead/component.rb
+++ b/lib/findingaids/ead/component.rb
@@ -65,6 +65,7 @@ class Findingaids::Ead::Component < SolrEad::Component
     Solrizer.insert_field(solr_doc, "dao",        get_ead_dao_facet,                            :facetable)
     Solrizer.insert_field(solr_doc, "place",      get_ead_places,                               :displayable, :facetable)
     Solrizer.insert_field(solr_doc, "subject",    get_ead_subject_facets,                       :facetable)
+    Solrizer.insert_field(solr_doc, "breadcrumb", bread_crumb(solr_doc),                        :displayable)
 
     # Get the collection field
     Solrizer.set_field(solr_doc,    "collection", collection_name(solr_doc),                    :searchable, :displayable, :facetable)


### PR DESCRIPTION
@barnabyalter @NYULibraries/finding-aids ,

I'm creating a PR for [brief history display for collection result](https://www.pivotaltracker.com/n/projects/1025988/stories/76553726) and [brief history non-collection](https://www.pivotaltracker.com/n/projects/1025988/stories/87726224). I have a rspec test that 's failing because I get an error

Failures:

  1) Findingaids::Ead::Component#to_solr #heading 
     Failure/Error: let(:solr_doc) { document.to_solr }
     NoMethodError:
       undefined method `length' for nil:NilClass
     # ./lib/findingaids/ead/behaviors/component.rb:26:in `title_for_heading'
     # ./lib/findingaids/ead/behaviors/component.rb:41:in `bread_crumb'
     # ./lib/findingaids/ead/component.rb:68:in `to_solr'
     # ./spec/lib/findingaids/ead/component_spec.rb:184:in `block (4 levels) in <top (required)>'
     # ./spec/lib/findingaids/ead/component_spec.rb:185:in `block (4 levels) in <top (required)>'
     # ./spec/lib/findingaids/ead/component_spec.rb:186:in `block (4 levels) in <top (required)>'

Finished in 13.74 seconds
235 examples, 1 failure

I had added a new field "breadcrumb" to solr, so that I could easily parse and generate the "contained in" navigation trail and rspec is having issues with that. The code does work, so I'm not quite sure where to go from here. I had tried adding a breadcrumb field and I was still getting an error. I am still working to see if I can get it fixed, but I thought I would ask you to see if you could help me find the problem. Thanks so much. I still need to add other rspec and cucumber tests to this. Thanks in advance.

Esha