### PR TITLE
Just force a dummy FactorGirl user for the UserSession

### DIFF
--- a/features/support/login.rb
+++ b/features/support/login.rb
@@ -1,30 +1,30 @@
 ## Two strategies for mocking login
 
 # 1) Open up ApplicationController and set the current_user method to a dummy user
-# ApplicationController.class_eval do
-#   def current_user
-#     @current_user ||= FactoryGirl.build(:user)
-#   end
-# end
-
-# 2) Open up UserSession and set pds_handle to a handle which we have previously recorded a VHS for
-UserSession.class_eval do
-
-  # Override pds_handle to use ENV['PDS_HANDLE'] if it's available
-  def pds_handle
-    # Set PDS handle in an environment variable if you want to
-    # override super, e.g. ENV['PDS_HANDLE'] = 'GIS_Cataloger'
-    pds_handle_lambda.call || super
-  end
-
-  # Read PDS handle from an evironment variable, PDS_HANDLE
-  # It will return nil if ENV['PDS_HANDLE'] is not set
-  def pds_handle_lambda
-    -> { ENV['PDS_HANDLE'] }
-  end
-  private :pds_handle_lambda
-
-  def attempt_sso?
-    false
+ApplicationController.class_eval do
+  def current_user
+    @current_user ||= FactoryGirl.build(:user)
   end
 end
+
+# 2) Open up UserSession and set pds_handle to a handle which we have previously recorded a VHS for
+# UserSession.class_eval do
+#
+#   # Override pds_handle to use ENV['PDS_HANDLE'] if it's available
+#   def pds_handle
+#     # Set PDS handle in an environment variable if you want to
+#     # override super, e.g. ENV['PDS_HANDLE'] = 'GIS_Cataloger'
+#     pds_handle_lambda.call || super
+#   end
+#
+#   # Read PDS handle from an evironment variable, PDS_HANDLE
+#   # It will return nil if ENV['PDS_HANDLE'] is not set
+#   def pds_handle_lambda
+#     -> { ENV['PDS_HANDLE'] }
+#   end
+#   private :pds_handle_lambda
+#
+#   def attempt_sso?
+#     false
+#   end
+# end


### PR DESCRIPTION
Just force a dummy FactorGirl user for the UserSession, it doesn't matter because the whole login system is in transition and we don't need to jump through hoops to trick PDS

@eshadatta The commit message says most of it. Just use method one from the Login mocking. Libraries login is shifting to OAuth2 anyway and that is easy to integrate with Rails testing so we're not going to break our backs making the old method (i.e. authpds) work here.