### PR TITLE
Feature/display order tweaks

### DIFF
--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -6,22 +6,22 @@ module ResultsHelper
     doc[:document][doc[:field]].join(", ").truncate(450).html_safe
  end
 
-   
+
   ##
   # Render clean faceted link to items in series
   def render_series_facet_link(doc)
     series = doc[:document][Solrizer.solr_name("parent_unittitles", :displayable)]
-   
+
     coll = doc[:document][Solrizer.solr_name("collection", :displayable)].first
 
     item_title = doc[:document][Solrizer.solr_name("unittitle", :displayable)][0]
-    
-    title = content_tag(:span,item_title, class: "result_ut") 
+
+    title = content_tag(:span,item_title, class: "result_ut")
     coll_link = link_to(coll,add_clean_facet_params_and_redirect([collection_facet, coll]))
     links_to_series = []
     series.each do |ser|
       links_to_series << link_to(ser, add_clean_facet_params_and_redirect([series_facet, ser],[collection_facet, coll]))
-    end unless doc[:document][Solrizer.solr_name("parent_unittitles", :displayable)].nil? # if there is no series info at all 
+    end unless doc[:document][Solrizer.solr_name("parent_unittitles", :displayable)].nil? # if there is no series info at all
 
     [coll_link,links_to_series,title].reject(&:blank?).join(" >> ").html_safe
   end
@@ -31,20 +31,18 @@ module ResultsHelper
   def is_collection?(field_config, doc)
     doc.is_archival_collection?
   end
- 
+
   def render_repository_facet_link(doc)
     repository_label repositories.find{|key,hash| hash["admin_code"] == doc}[1]["url"]
   end
-  
+
   # This is a bit of a hack to work around the fact that we don't want to change repo names
-  # in the source repository folder hierarchy. Since folder names match admin_codes, 
+  # in the source repository folder hierarchy. Since folder names match admin_codes,
   # this looks up the looks up the repo by admin_code and grabs the URL.
   def render_repository_link(doc)
     repos_id = Solrizer.solr_name("repository", :stored_sortable)
     if doc.is_a?(Hash) && doc[:document].present? && doc[:document][repos_id].present?
       link_to_repository repositories.find{|key,hash| hash["admin_code"] == doc[:document][repos_id]}[1]["url"]
-    elsif repositories[doc].present?
-      repositories[doc]["display"]
     end
   end
 
@@ -98,7 +96,7 @@ module ResultsHelper
     end
   end
 
-  
+
   # Get icon from format type
   def document_icon(doc)
     doc.normalized_format

--- a/features/brief_results_display.feature
+++ b/features/brief_results_display.feature
@@ -1,35 +1,42 @@
 Feature: Brief result display
-  In order to view relevant fields in search results
+  In order to be able to pinpoint the item I'm looking for
   As a researcher
   I want to see relevant fields in the brief search display.
 
-  
-  Scenario: See brief results display at the collection level 
+  Scenario: Brief results display appropiate fields at the collection level
     Given I am on the brief results page
-    And I limit my search to "Archival Collection" under the "Level" category
+    When I limit my search to "Archival Collection" under the "Level" category
+    And I limit my search to "Mark Bloch Postal Art Network (PAN) Archive" under the "Collection" category
     Then I should see fields in the following order and value:
-    | Format | Archival Collection |
-    | Date range | Inclusive, 1978-2012 |
-    | Abstract | Mark Bloch is an American fine artist and writer whose work utilizes both visuals and text to explore ideas of long distance communication. This collection contains thousands of examples of original “mail art” sent to and collected by Mark Bloch in New York City from all fifty states and dozens of countries in the form of objects, envelopes, artwork, and enclosures as well as publications, postcards and announcements documenting avant garde cu... |
-    | Library | The Fales Library & Special Collections |
-    | Call no | MSS 170 |
-    And I should see "Abstract" be "450" characters or less
-    And I should see "Search all archival materials within this collection" between "Abstract" and "Library"
-    When I click on "Search all archival materials within this collection" within css class "dd.blacklight-collection_ssm"
-    Then I should see search results
+      | Format | Archival Collection |
+      | Date range | Inclusive, 1978-2012 |
+      | Abstract | Mark Bloch is an American fine artist and writer whose work utilizes both visuals and text to explore ideas of long distance communication. This collection contains thousands of examples of original “mail art” sent to and collected by Mark Bloch in New York City from all fifty states and dozens of countries in the form of objects, envelopes, artwork, and enclosures as well as publications, postcards and announcements documenting avant garde cu... |
+      | | Search all archival materials within this collection |
+      | Library | The Fales Library & Special Collections |
+      | Call no | MSS 170 |
+    And the "Abstract" field should be "450" characters or less
 
-
-  Scenario: See brief results display at non-collection level
+  Scenario: Brief results display at the component level
     Given I search on the phrase "Minka"
     Then I should see fields in the following order and value:
-    | Format | Archival Object |
-    | Contained in | Oral History of the American Left: Radical Histories >> Minka Alesh |
-    | Date range | Oct 26, 1982 |
-    | Library | The Tamiment Library & Robert F. Wagner Labor Archives |
-    | Location | CD: Access OH-02-159, Box: 1, CD: Alesh 1, Cassette: 1, CD: ohaloh020146p1 / /ohaloh020146p2, Box: 1, Cassette: 1 |
-    And I should see "To request this item, please note the following information" between "Date range" and "Library"
-    When I click on "Oral History of the American Left: Radical Histories" within css class "dd.blacklight-heading_ssm" 
-    Then I should see search results
+      | Format | Archival Object |
+      | Contained in | Oral History of the American Left: Radical Histories >> Minka Alesh |
+      | Date range | Oct 26, 1982 |
+      | | To request this item, please note the following information |
+      | Library | The Tamiment Library & Robert F. Wagner Labor Archives |
+      | Location | CD: Access OH-02-159, Box: 1, CD: Alesh 1, Cassette: 1, CD: ohaloh020146p1 / /ohaloh020146p2, Box: 1, Cassette: 1 |
 
- 
- 
+  Scenario: Link to search all materials within collection launches faceted search
+    Given I am on the default search page
+    When I limit my search to "Archival Collection" under the "Level" category
+    And I limit my search to "Mark Bloch Postal Art Network (PAN) Archive" under the "Collection" category
+    When I click on "Search all archival materials within this collection" within the first result
+    Then the limit "Archival Collection" should be selected under the "Level" category
+    And the limit "Mark Bloch Postal Art Network (PAN) Archive" should be selected under the "Collection" category
+    And I should see search results
+
+  Scenario: Link to collection in component result launches faceted search
+    Given I search on the phrase "Minka"
+    When I click on "Oral History of the American Left: Radical Histories" within the first result
+    Then the limit "Oral History of the American Left: Radical Histories" should be selected under the "Collection" category
+    And I should see search results

--- a/features/facets/subject_facet.feature
+++ b/features/facets/subject_facet.feature
@@ -10,6 +10,6 @@ Feature: Subject facet
 
   Scenario: Filter search results by a name facet
     Given I am on the default search page
-    When I search on the phrase "radical"
+    When I search on the phrase "Broadcasting"
     And I limit my search to "Art and society." under the "Subject" category
     Then I should see search results

--- a/features/step_definitions/brief_results_display_steps.rb
+++ b/features/step_definitions/brief_results_display_steps.rb
@@ -3,39 +3,22 @@ Given(/^I am on the brief results page$/) do
   search_phrase('bloch')
 end
 
-And(/^I should see "(.*?)" be "(\d.*?)" characters or less/) do |label,len|
-  class_name = get_class_name(label)
-  within(page.first("dl")) do
-    page.find('dd.blacklight-'"#{class_name}").text.length.should be <= len.to_i
-  end
+Then(/^the "(.*?)" field should be "(\d.*?)" characters or less$/) do |label, length|
+  expect(documents_list.first.find(:xpath, "//dt[text()='#{label}:']/following-sibling::dd[1]").text.length).to be <= length.to_i
 end
-
-And(/^I should see "(.*?)" between "(.*?)" and "(.*?)"/) do |label,field1,field2|
-  within(page.first("dl")) do
-    f1 = page.find(:xpath, "dt[text()='#{field1}:']/following-sibling::dd[2]").text
-    f2 = page.find(:xpath, "dt[text()='#{field2}:']/preceding-sibling::dd[1]").text
-    f1.should be == label
-    f1.should be == f2
-  end
-end
-
-
-When(/^I click on "(.*?)" within css class "(.*?)"/) do |link,class_name|
-  within(page.first("dl")) do
-    within(:css,class_name) do
-      find('a', text: link).click
-    end
-  end
-end
-
 
 Then(/^I should see fields in the following order and value:$/) do |table|
-  within(page.first("dl")) do
-    table.rows_hash.each do |label, value|
-      class_name = get_class_name(label)
-      expect(page.find('dt.blacklight-'"#{class_name}")).to have_content "#{label}:"
-      expect(page.find('dd.blacklight-'"#{class_name}")).to have_content "#{value}"
-
+  table.rows_hash.each do |label, value|
+    unless label.blank?
+      expect(documents_list.first.find(:xpath, "//dt[text()='#{label}:']/following-sibling::dd[1]")).to have_content
+    else
+      expect(documents_list.first.find(:xpath, "//dd//*[text()='#{value}']")).to have_content
     end
+  end
+end
+
+When(/^I click on "(.*?)" within the first result$/) do |link_text|
+  within("#documents .document:first-child") do
+    click_link link_text
   end
 end

--- a/features/step_definitions/facet_steps.rb
+++ b/features/step_definitions/facet_steps.rb
@@ -1,12 +1,10 @@
 ##
 # Faceting steps
 Given(/^I (limit|filter) my search to "(.*?)" under the "(.*?)" category$/) do |a, facet, category|
-  ensure_root_path
   limit_by_facet(category, facet)
 end
 
 When(/^I limit my results to "(.*?)" under the "(.*?)" category$/) do |facet, category|
-  ensure_root_path
   limit_by_facet(category, facet)
 end
 
@@ -21,4 +19,8 @@ Then(/^I should see facets in the following order:$/) do |table|
   table.rows_hash.each do |order, value|
     expect(page.find("#facets div.panel-group > div:nth-child(#{order})").text).to eq(value)
   end
+end
+
+Then(/^the limit "(.*?)" should be selected under the "(.*?)" category$/) do |facet, category|
+  expect(page.find(:xpath, "//span[@class='facet-label']/span[@class='selected'][text()='#{facet}']")).to have_content
 end

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -119,4 +119,3 @@ Then(/^(those|that) result(s)? should (include|be):$/) do |pronoun, plural, mult
     expect(documents_list_container).to have_content result_title
   end
 end
-

--- a/spec/helpers/results_helper_spec.rb
+++ b/spec/helpers/results_helper_spec.rb
@@ -37,7 +37,7 @@ describe ResultsHelper do
       it { should eql("<b>The Title</b>") }
     end
     context "when the there are more than 450 characters in a field" do
-       let(:solr_document) { create(:solr_document, unittitle: ["Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu ped"]) } 
+       let(:solr_document) { create(:solr_document, unittitle: ["Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu ped"]) }
        it { should eql "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis e..."}
     end
   end
@@ -147,10 +147,10 @@ describe ResultsHelper do
     end
   end
 
- 
+
   describe "#render_series_facet_link" do
     let(:field) { :heading_ssm }
-    let(:solr_document) { create(:solr_document, parent_unittitles: ["Series I", "Subseries IV"]) }     
+    let(:solr_document) { create(:solr_document, parent_unittitles: ["Series I", "Subseries IV"]) }
     subject { render_series_facet_link(document) }
     it { should eql "<a href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things\">Bytsura Collection of Things</a> >> <a href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Series I</a> >> <a href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Subseries+IV\">Subseries IV</a> >> <span class=\"result_ut\">The Title</span>" }
     it { expect(sanitize(subject)).to eql("Bytsura Collection of Things &gt;&gt; Series I &gt;&gt; Subseries IV &gt;&gt; The Title") }
@@ -184,7 +184,7 @@ describe ResultsHelper do
     it { should eql({"f"=>{"series_sim"=>document[:document][:unittitle_ssm], "collection_sim"=>["Bytsura Collection of Things"]}, "action"=>"index", "controller"=>"catalog"}) }
   end
 
- 
+
   describe "#link_to_document" do
     subject { link_to_document(collection, heading) }
     let(:collection) { document[:document] }
@@ -198,6 +198,17 @@ describe ResultsHelper do
     context "when document is item level" do
       let(:solr_document) { create(:solr_document, format: ["Archival Object"], id: "bytsura", ead: "bytsura", parent: ["1234"], ref: "5678") }
       it { should eql("<a href=\"http://dlib.nyu.edu/findingaids/html/fales/bytsura/dsc1234.html#5678\" target=\"_blank\">Guide to titling finding aids</a>") }
+    end
+  end
+
+  describe "#is_collection?" do
+    subject { is_collection?({}, document[:document]) }
+    context "when document is a collection" do
+      it { should be_true }
+    end
+    context "when document is a component" do
+      let(:solr_document) { create(:solr_document, format: ["Archival Object"]) }
+      it { should be_false }
     end
   end
 


### PR DESCRIPTION
@eshadatta I changed the wording of the cucumber features a little bit and simplified the steps.

Mainly note that each scenario should test one piece of functionality and if you notice yourself doing `When` `Then` `When` `Then` you probably want to separate into separate scenarios. Also if you are conducting a user action use `When` instead of including in the `Given`.

I also added an rspec for `is_collection?` to get our code coverage back up. 

I think if you merge this back to your base and travis passes then this is ready to merge back to development.