### PR TITLE
Add Series translation to locales, this requires an explicit translation because it is not configured as a facet in blacklight config but we still want to use it as a facet for linking

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,4 +39,4 @@ en:
     help:
       email: "Email a list of my bookmarks"
       citation: "Display a list of my bookmarks"
-
+  Series sim: Series


### PR DESCRIPTION
Delivers #92557058

@eshadatta For once the error message was actually saying exactly what was wrong. The translation from the en.yml locale was missing for "Series sim", which was the default facet label for pulling Series facet out because we did not explicitly configure the facet in the blacklight catalog. 

We are using Series for a purpose outside of the default blacklight method. We are using it as a facet, but we haven't configured it as a facet. So blacklight operates under the understanding that facets are facets and that's it. 

Two solutions:

1) Add the facet into the blacklight config by updating the `facets_field` function with another line:

```ruby
{ field: "series", label: "Series", limit: 20 }
```

But then it will appear on the left facets bar and that is counted to another user story. So we can messily try to hide it then or just add the following line to en.yml:

2) `Series sim: Series` so that the translator knows what text to use when trying to pull out `t('Series sim')`