### PR TITLE
Just match on EADID without filename when deleting from commit messag…

### DIFF
--- a/lib/findingaids/ead/indexer.rb
+++ b/lib/findingaids/ead/indexer.rb
@@ -99,7 +99,9 @@ private
   end
 
   def get_eadid_from_message(file, message)
-    eadid_matches = message.match(/EADID='(.+?)'/)
+    # Strip out initial folder name to match filename in commit message
+    file_without_prefix = file.split("/")[1..-1].join("/")
+    eadid_matches = message.match(/#{file_without_prefix} EADID='(.+?)'/)
     eadid_matches.captures.first unless eadid_matches.nil?
   end
 

--- a/lib/findingaids/ead/indexer.rb
+++ b/lib/findingaids/ead/indexer.rb
@@ -99,7 +99,7 @@ private
   end
 
   def get_eadid_from_message(file, message)
-    eadid_matches = message.match(/#{file} EADID='(.+?)'/)
+    eadid_matches = message.match(/EADID='(.+?)'/)
     eadid_matches.captures.first unless eadid_matches.nil?
   end
 


### PR DESCRIPTION
…e because filename was coming through with subdirectory prefix, ie findingaids_eads