### PR TITLE
Change blacklight routes to have blacklight. prefix for new BL versio…

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -130,13 +130,13 @@ class CatalogController < ApplicationController
     # config.add_index_field 'lc_callnum_display', label: 'Call number'
 
     config.add_index_field solr_name("format",            :displayable),  :label => "Format", :helper_method => :render_field_item
-    config.add_index_field solr_name("heading",           :displayable),  :label => "Contained in", :helper_method => :render_contained_in_links, unless: :is_collection?
+    config.add_index_field solr_name("heading",           :displayable),  :label => "Contained in", :helper_method => :render_contained_in_links, unless: 'is_collection?'
     config.add_index_field solr_name("unitdate",          :displayable),  :label => "Date range", :helper_method => :render_field_item
     config.add_index_field solr_name("abstract",          :displayable),  :label => "Abstract", :helper_method => :render_field_item
     config.add_index_field solr_name("collection",        :displayable),  :label => "Archival Collection", :helper_method => :render_parent_facet_link
     config.add_index_field solr_name("repository",        :stored_sortable), label: "Library", helper_method: :render_repository_link
-    config.add_index_field solr_name("unitid",            :displayable),  :label => "Call no", :helper_method => :render_field_item, if: :is_collection?
-    config.add_index_field solr_name("collection_unitid", :displayable),  :label => "Collection call no", :helper_method => :render_field_item, unless: :is_collection?
+    config.add_index_field solr_name("unitid",            :displayable),  :label => "Call no", :helper_method => :render_field_item, if: 'is_collection?'
+    config.add_index_field solr_name("collection_unitid", :displayable),  :label => "Collection call no", :helper_method => :render_field_item, unless: 'is_collection?'
     config.add_index_field solr_name("location",          :displayable),  :label => "Location", :helper_method => :render_field_item
 
     # solr fields to be displayed in the show (single result) view

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,9 @@
 module ApplicationHelper
 
   # Link to the finding aid with the passed in label
-  def link_to_findingaid(doc, label = nil)
+  def link_to_findingaid(doc, label = nil, opts = {})
     url = get_url_for_findingaid_from_document(doc)
-    link_to (label || url), url, { :target => "_blank" }
+    link_to (label || url), url, opts.merge({ :target => "_blank" })
   end
 
   # Abstract actually constructing the url to the finding aids document

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -9,8 +9,8 @@
   </li>
   <% end %>
   <% if current_user %>
-  <li><%= link_to t('blacklight.header_links.saved_searches'), saved_searches_path %></li>
+  <li><%= link_to t('blacklight.header_links.saved_searches'), blacklight.saved_searches_path %></li>
   <% end %>
-  <li><%= link_to t('blacklight.header_links.search_history'), search_history_path %></li>
+  <li><%= link_to t('blacklight.header_links.search_history'), blacklight.search_history_path %></li>
 </ul>
 <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  config.active_support.deprecation = :log
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -5,3 +5,4 @@
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
 # Rails.backtrace_cleaner.remove_silencers!
+Deprecation.default_deprecation_behavior = :silence

--- a/spec/helpers/results_helper_spec.rb
+++ b/spec/helpers/results_helper_spec.rb
@@ -113,7 +113,7 @@ describe ResultsHelper do
     subject { render_parent_facet_link(document) }
     context "when document is a collection level item" do
       let(:field) {:collection_ssm}
-      it { should eql "<a class=\"search_within\" href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things\">Search all archival materials within this collection</a>" }
+      it { should eql "<a class=\"search_within\" href=\"/?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things\">Search all archival materials within this collection</a>" }
       context "when document title is nil" do
         let(:solr_document) { create(:solr_document, unittitle: []) }
         it { should eql nil }
@@ -122,7 +122,7 @@ describe ResultsHelper do
     context "when document is a series level item" do
       let(:field) {:collection_ssm}
       let(:solr_document) { create(:solr_document, format: ["Archival Series"], unittitle: ["Series I"] ) }
-      it { should eql "<a class=\"search_within\" href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Search all archival materials within this series</a>" }
+      it { should eql "<a class=\"search_within\" href=\"/?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Search all archival materials within this series</a>" }
       context "when document title is nil" do
         let(:solr_document) { create(:solr_document, format: ["Archival Series"], unittitle: []) }
         it { should eql "<span class=\"search_within\">Series doesn&#39;t have unittitle you can&#39;t search within it</span>" }
@@ -138,7 +138,7 @@ describe ResultsHelper do
     let(:field) {:collection_ssm}
     subject { render_search_within_collection_instructions(document) }
     context "when collection has title" do
-      it { should eql "<a class=\"search_within\" href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things\">Search all archival materials within this collection</a>" }
+      it { should eql "<a class=\"search_within\" href=\"/?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things\">Search all archival materials within this collection</a>" }
     end
     context "when collection doesn't have title" do
       let(:solr_document) { create(:solr_document, unittitle: []) }
@@ -151,7 +151,7 @@ describe ResultsHelper do
     subject { render_search_within_series_instructions(document) }
     context "when series has title" do
       let(:solr_document) { create(:solr_document, format: ["Archival Series"], unittitle: ["Series I"] ) }
-      it { should eql "<a class=\"search_within\" href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Search all archival materials within this series</a>" }
+      it { should eql "<a class=\"search_within\" href=\"/?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Search all archival materials within this series</a>" }
     end
     context "when series doesn't have title" do
       let(:solr_document) { create(:solr_document, format: ["Archival Series"], unittitle: []) }
@@ -163,14 +163,14 @@ describe ResultsHelper do
   describe "#render_collection_facet_link" do
     let(:field) {:collection_ssm}
     subject { render_collection_facet_link(document) }
-    it { should eql "<a class=\"search_within\" href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things\">Search all archival materials within this collection</a>" }
+    it { should eql "<a class=\"search_within\" href=\"/?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things\">Search all archival materials within this collection</a>" }
   end
 
   describe "#render_series_facet_link" do
     let(:field) {:collection_ssm}
     let(:solr_document) { create(:solr_document, format: ["Archival Series"], unittitle: ["Series I"] ) }
     subject { render_series_facet_link(document) }
-    it { should eql "<a class=\"search_within\" href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Search all archival materials within this series</a>" }
+    it { should eql "<a class=\"search_within\" href=\"/?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Search all archival materials within this series</a>" }
   end
 
   describe "#render_request_item_istructions" do
@@ -182,7 +182,7 @@ describe ResultsHelper do
     let(:field) { :heading_ssm }
     let(:solr_document) { create(:solr_document, parent_unittitles: ["Series I", "Subseries IV"]) }
     subject { render_contained_in_links(document) }
-    it { should eql "<a href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things\">Bytsura Collection of Things</a> >> <a href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Series I</a> >> <a href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Subseries+IV\">Subseries IV</a> >> <span class=\"unittitle\">The Title</span>" }
+    it { should eql "<a href=\"/?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things\">Bytsura Collection of Things</a> >> <a href=\"/?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Series I</a> >> <a href=\"/?f%5Bcollection_sim%5D%5B%5D=Bytsura+Collection+of+Things&amp;f%5Bseries_sim%5D%5B%5D=Subseries+IV\">Subseries IV</a> >> <span class=\"unittitle\">The Title</span>" }
     it { expect(sanitize_html(subject)).to eql("Bytsura Collection of Things &gt;&gt; Series I &gt;&gt; Subseries IV &gt;&gt; The Title") }
   end
 
@@ -259,12 +259,12 @@ describe ResultsHelper do
 
   describe "#link_to_collection" do
     subject { link_to_collection("The Collection") }
-    it { should eql "<a href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=The+Collection\">The Collection</a>" }
+    it { should eql "<a href=\"/?f%5Bcollection_sim%5D%5B%5D=The+Collection\">The Collection</a>" }
   end
 
   describe "#links_to_series" do
     subject { links_to_series(["Series I", "Series II"], "The Collection").join(" >> ") }
-    it { should eql "<a href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=The+Collection&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Series I</a> >> <a href=\"/catalog?f%5Bcollection_sim%5D%5B%5D=The+Collection&amp;f%5Bseries_sim%5D%5B%5D=Series+II\">Series II</a>" }
+    it { should eql "<a href=\"/?f%5Bcollection_sim%5D%5B%5D=The+Collection&amp;f%5Bseries_sim%5D%5B%5D=Series+I\">Series I</a> >> <a href=\"/?f%5Bcollection_sim%5D%5B%5D=The+Collection&amp;f%5Bseries_sim%5D%5B%5D=Series+II\">Series II</a>" }
   end
 
   describe "#sanitize_html" do


### PR DESCRIPTION
…n; Helper methods in catalog controller requires quotes when including question mark

@ericgriffis Found that blacklight routes now need a `blacklight.` prefix. And apparently the way the catalog controller config sends the helper methods requires quotes if the symbol has a question mark, i.e. `:is_collection?` became `'is_collection?'`